### PR TITLE
feat(www): add Google OAuth integration

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -25,7 +25,8 @@
     "tailwind-merge": "2.2.1",
     "tailwindcss-animate": "^1.0.7",
     "ts-pattern": "^5.1.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "env": "workspace:*"
   },
   "devDependencies": {
     "@biomejs/biome": "1.5.3",

--- a/apps/www/src/lib/auth.ts
+++ b/apps/www/src/lib/auth.ts
@@ -1,0 +1,71 @@
+import {env} from './env';
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+const SCOPES = 'openid email profile';
+
+type GoogleTokenResponse = {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  id_token?: string;
+};
+
+type GoogleUserInfo = {
+  id: string;
+  email: string;
+  name: string;
+  picture: string;
+};
+
+export function buildGoogleAuthUrl(): string {
+  const params = new URLSearchParams({
+    client_id: env.GOOGLE_CLIENT_ID,
+    redirect_uri: env.GOOGLE_CALLBACK_URL,
+    response_type: 'code',
+    scope: SCOPES,
+    access_type: 'offline',
+    prompt: 'select_account',
+  });
+
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+}
+
+export async function exchangeCodeForTokens(code: string): Promise<GoogleTokenResponse> {
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: new URLSearchParams({
+      code,
+      client_id: env.GOOGLE_CLIENT_ID,
+      client_secret: env.GOOGLE_CLIENT_SECRET,
+      redirect_uri: env.GOOGLE_CALLBACK_URL,
+      grant_type: 'authorization_code',
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Google token exchange failed (${String(response.status)}): ${body}`);
+  }
+
+  return response.json() as Promise<GoogleTokenResponse>;
+}
+
+export async function fetchGoogleUserInfo(accessToken: string): Promise<GoogleUserInfo> {
+  const response = await fetch(GOOGLE_USERINFO_URL, {
+    headers: {Authorization: `Bearer ${accessToken}`},
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Google userinfo fetch failed (${String(response.status)}): ${body}`);
+  }
+
+  return response.json() as Promise<GoogleUserInfo>;
+}
+
+export function isAllowedEmail(email: string): boolean {
+  return email.toLowerCase() === env.ALLOWED_EMAIL.toLowerCase();
+}

--- a/apps/www/src/lib/env.ts
+++ b/apps/www/src/lib/env.ts
@@ -1,0 +1,13 @@
+import {parseEnv} from 'env';
+import {z} from 'zod';
+
+const envSchema = z.object({
+  GOOGLE_CLIENT_ID: z.string(),
+  GOOGLE_CLIENT_SECRET: z.string(),
+  GOOGLE_CALLBACK_URL: z.string().url(),
+  ALLOWED_EMAIL: z.string().email(),
+  SESSION_SECRET: z.string().min(32),
+  API_KEY: z.string(),
+});
+
+export const env = parseEnv(envSchema);

--- a/apps/www/src/lib/session.ts
+++ b/apps/www/src/lib/session.ts
@@ -1,0 +1,86 @@
+import {createServerFn} from '@tanstack/react-start';
+import {getCookie, setCookie} from '@tanstack/react-start/server';
+import {env} from './env';
+
+const SESSION_COOKIE = 'schwankie_session';
+const MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
+type SessionData = {
+  email: string;
+  authenticated: boolean;
+};
+
+type SessionPayload = {
+  data: SessionData;
+  expires: number;
+  sig: string;
+};
+
+async function sign(value: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(env.SESSION_SECRET),
+    {name: 'HMAC', hash: 'SHA-256'},
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value));
+  return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+async function verify(value: string, signature: string): Promise<boolean> {
+  const expected = await sign(value);
+  return expected === signature;
+}
+
+export async function createSession(email: string): Promise<void> {
+  const data: SessionData = {email, authenticated: true};
+  const expires = Date.now() + MAX_AGE * 1000;
+  const payload = JSON.stringify({data, expires});
+  const sig = await sign(payload);
+  const cookie: SessionPayload = {data, expires, sig};
+
+  setCookie(SESSION_COOKIE, btoa(JSON.stringify(cookie)), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: MAX_AGE,
+  });
+}
+
+export async function getSession(): Promise<SessionData | null> {
+  const raw = getCookie(SESSION_COOKIE);
+  if (!raw) return null;
+
+  try {
+    const cookie: SessionPayload = JSON.parse(atob(raw));
+    if (Date.now() > cookie.expires) return null;
+
+    const payload = JSON.stringify({data: cookie.data, expires: cookie.expires});
+    const valid = await verify(payload, cookie.sig);
+    if (!valid) return null;
+
+    return cookie.data;
+  } catch {
+    return null;
+  }
+}
+
+export async function destroySession(): Promise<void> {
+  setCookie(SESSION_COOKIE, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+}
+
+export const getAuthState = createServerFn({method: 'GET'}).handler(async () => {
+  const session = await getSession();
+  if (!session?.authenticated) {
+    return {authenticated: false as const};
+  }
+  return {authenticated: true as const, email: session.email};
+});

--- a/apps/www/src/lib/session.ts
+++ b/apps/www/src/lib/session.ts
@@ -16,21 +16,26 @@ type SessionPayload = {
   sig: string;
 };
 
-async function sign(value: string): Promise<string> {
-  const key = await crypto.subtle.importKey(
+async function importKey(usage: 'sign' | 'verify'): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
     'raw',
     new TextEncoder().encode(env.SESSION_SECRET),
     {name: 'HMAC', hash: 'SHA-256'},
     false,
-    ['sign'],
+    [usage],
   );
+}
+
+async function sign(value: string): Promise<string> {
+  const key = await importKey('sign');
   const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value));
   return btoa(String.fromCharCode(...new Uint8Array(signature)));
 }
 
 async function verify(value: string, signature: string): Promise<boolean> {
-  const expected = await sign(value);
-  return expected === signature;
+  const key = await importKey('verify');
+  const sigBytes = Uint8Array.from(atob(signature), (c) => c.charCodeAt(0));
+  return crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(value));
 }
 
 export async function createSession(email: string): Promise<void> {

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -10,33 +10,53 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthLoginRouteImport } from './routes/auth/login'
+import { Route as AuthCallbackRouteImport } from './routes/auth/callback'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthLoginRoute = AuthLoginRouteImport.update({
+  id: '/auth/login',
+  path: '/auth/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthCallbackRoute = AuthCallbackRouteImport.update({
+  id: '/auth/callback',
+  path: '/auth/callback',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/auth/callback': typeof AuthCallbackRoute
+  '/auth/login': typeof AuthLoginRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/auth/callback': typeof AuthCallbackRoute
+  '/auth/login': typeof AuthLoginRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/auth/callback': typeof AuthCallbackRoute
+  '/auth/login': typeof AuthLoginRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/auth/callback' | '/auth/login'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/auth/callback' | '/auth/login'
+  id: '__root__' | '/' | '/auth/callback' | '/auth/login'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AuthCallbackRoute: typeof AuthCallbackRoute
+  AuthLoginRoute: typeof AuthLoginRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -48,11 +68,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/auth/login': {
+      id: '/auth/login'
+      path: '/auth/login'
+      fullPath: '/auth/login'
+      preLoaderRoute: typeof AuthLoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/callback': {
+      id: '/auth/callback'
+      path: '/auth/callback'
+      fullPath: '/auth/callback'
+      preLoaderRoute: typeof AuthCallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AuthCallbackRoute: AuthCallbackRoute,
+  AuthLoginRoute: AuthLoginRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -1,9 +1,20 @@
 import {HeadContent, Outlet, Scripts, createRootRoute} from '@tanstack/react-router';
+import {createServerFn} from '@tanstack/react-start';
 import {AppShell} from '@www/components/shell/app-shell';
 import '../globals.css';
+import {destroySession, getAuthState} from '../lib/session';
+
+const logout = createServerFn({method: 'POST'}).handler(async () => {
+  await destroySession();
+  throw new Response(null, {status: 302, headers: {Location: '/'}});
+});
 
 export const Route = createRootRoute({
   notFoundComponent: NotFound,
+  beforeLoad: async () => {
+    const auth = await getAuthState();
+    return {auth};
+  },
   head: () => ({
     meta: [{charSet: 'utf-8'}, {name: 'viewport', content: 'width=device-width, initial-scale=1'}],
     links: [

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -4,7 +4,7 @@ import {AppShell} from '@www/components/shell/app-shell';
 import '../globals.css';
 import {destroySession, getAuthState} from '../lib/session';
 
-const logout = createServerFn({method: 'POST'}).handler(async () => {
+export const logout = createServerFn({method: 'POST'}).handler(async () => {
   await destroySession();
   throw new Response(null, {status: 302, headers: {Location: '/'}});
 });

--- a/apps/www/src/routes/auth/callback.tsx
+++ b/apps/www/src/routes/auth/callback.tsx
@@ -15,8 +15,7 @@ async function processOAuthCode(code: string): Promise<{error: string | null}> {
 
     await createSession(userInfo.email);
     return {error: null};
-  } catch (err) {
-    console.error('OAuth callback error:', err);
+  } catch {
     return {error: 'auth_failed'};
   }
 }

--- a/apps/www/src/routes/auth/callback.tsx
+++ b/apps/www/src/routes/auth/callback.tsx
@@ -1,0 +1,56 @@
+import {createFileRoute, redirect} from '@tanstack/react-router';
+import {exchangeCodeForTokens, fetchGoogleUserInfo, isAllowedEmail} from '../../lib/auth';
+import {createSession} from '../../lib/session';
+
+async function processOAuthCode(code: string): Promise<{error: string | null}> {
+  'use server';
+
+  try {
+    const tokens = await exchangeCodeForTokens(code);
+    const userInfo = await fetchGoogleUserInfo(tokens.access_token);
+
+    if (!isAllowedEmail(userInfo.email)) {
+      return {error: 'unauthorized_email'};
+    }
+
+    await createSession(userInfo.email);
+    return {error: null};
+  } catch (err) {
+    console.error('OAuth callback error:', err);
+    return {error: 'auth_failed'};
+  }
+}
+
+export const Route = createFileRoute('/auth/callback')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    code: search.code as string | undefined,
+    error: search.error as string | undefined,
+  }),
+  loaderDeps: ({search}) => ({code: search.code, error: search.error}),
+  loader: async ({deps}) => {
+    if (deps.error) {
+      throw redirect({to: '/auth/login', search: {error: 'access_denied'}});
+    }
+
+    if (!deps.code) {
+      throw redirect({to: '/auth/login', search: {error: 'missing_code'}});
+    }
+
+    const result = await processOAuthCode(deps.code);
+
+    if (result.error) {
+      throw redirect({to: '/auth/login', search: {error: result.error}});
+    }
+
+    throw redirect({to: '/'});
+  },
+  component: CallbackPage,
+});
+
+function CallbackPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-text-muted">Authenticating...</p>
+    </div>
+  );
+}

--- a/apps/www/src/routes/auth/login.tsx
+++ b/apps/www/src/routes/auth/login.tsx
@@ -1,0 +1,40 @@
+import {createFileRoute} from '@tanstack/react-router';
+import {createServerFn} from '@tanstack/react-start';
+import {buildGoogleAuthUrl} from '../../lib/auth';
+
+const getGoogleAuthUrl = createServerFn({method: 'GET'}).handler(async () => {
+  return buildGoogleAuthUrl();
+});
+
+export const Route = createFileRoute('/auth/login')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    error: search.error as string | undefined,
+  }),
+  head: () => ({
+    meta: [{title: 'Sign in — schwankie'}],
+  }),
+  loader: async () => {
+    const authUrl = await getGoogleAuthUrl();
+    return {authUrl};
+  },
+  component: LoginPage,
+});
+
+function LoginPage() {
+  const {authUrl} = Route.useLoaderData();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="w-full max-w-sm space-y-6 text-center">
+        <h1 className="font-serif text-3xl text-text">schwankie</h1>
+        <p className="text-text-muted">Sign in to manage your links.</p>
+        <a
+          href={authUrl}
+          className="inline-block rounded-md bg-primary px-6 py-3 font-medium text-white transition-colors hover:bg-primary/90"
+        >
+          Sign in with Google
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/www/tests/lib/auth.test.ts
+++ b/apps/www/tests/lib/auth.test.ts
@@ -1,0 +1,40 @@
+import {describe, expect, it, mock} from 'bun:test';
+
+mock.module('../../src/lib/env', () => ({
+  env: {
+    ALLOWED_EMAIL: 'admin@example.com',
+    GOOGLE_CLIENT_ID: 'test-client-id',
+    GOOGLE_CLIENT_SECRET: 'test-secret',
+    GOOGLE_CALLBACK_URL: 'http://localhost:3000/auth/callback',
+    SESSION_SECRET: 'a'.repeat(32),
+    API_KEY: 'test-api-key',
+  },
+}));
+
+type AuthModule = typeof import('../../src/lib/auth');
+let isAllowedEmail: AuthModule['isAllowedEmail'];
+
+const mod = await import('../../src/lib/auth');
+isAllowedEmail = mod.isAllowedEmail;
+
+describe('isAllowedEmail', function () {
+  it('should return true for exact match', function () {
+    expect(isAllowedEmail('admin@example.com')).toBe(true);
+  });
+
+  it('should return true for case-insensitive match', function () {
+    expect(isAllowedEmail('Admin@Example.COM')).toBe(true);
+  });
+
+  it('should return false for non-matching email', function () {
+    expect(isAllowedEmail('other@example.com')).toBe(false);
+  });
+
+  it('should return false for empty string', function () {
+    expect(isAllowedEmail('')).toBe(false);
+  });
+
+  it('should return false for partial match', function () {
+    expect(isAllowedEmail('admin@example.co')).toBe(false);
+  });
+});

--- a/apps/www/tests/lib/auth.test.ts
+++ b/apps/www/tests/lib/auth.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, it, mock} from 'bun:test';
+import {beforeAll, describe, expect, it, mock} from 'bun:test';
 
 mock.module('../../src/lib/env', () => ({
   env: {
@@ -11,11 +11,12 @@ mock.module('../../src/lib/env', () => ({
   },
 }));
 
-type AuthModule = typeof import('../../src/lib/auth');
-let isAllowedEmail: AuthModule['isAllowedEmail'];
+let isAllowedEmail: (email: string) => boolean;
 
-const mod = await import('../../src/lib/auth');
-isAllowedEmail = mod.isAllowedEmail;
+beforeAll(async function () {
+  const mod = await import('../../src/lib/auth');
+  isAllowedEmail = mod.isAllowedEmail;
+});
 
 describe('isAllowedEmail', function () {
   it('should return true for exact match', function () {

--- a/apps/www/tests/lib/session.test.ts
+++ b/apps/www/tests/lib/session.test.ts
@@ -1,4 +1,4 @@
-import {afterEach, beforeEach, describe, expect, it, mock} from 'bun:test';
+import {beforeAll, beforeEach, describe, expect, it, mock} from 'bun:test';
 
 const SESSION_SECRET = 'a'.repeat(32);
 const cookies: Record<string, string> = {};
@@ -25,15 +25,16 @@ mock.module('../../src/lib/env', () => ({
   },
 }));
 
-type SessionModule = typeof import('../../src/lib/session');
-let createSession: SessionModule['createSession'];
-let getSession: SessionModule['getSession'];
-let destroySession: SessionModule['destroySession'];
+let createSession: (email: string) => Promise<void>;
+let getSession: () => Promise<{email: string; authenticated: boolean} | null>;
+let destroySession: () => Promise<void>;
 
-const mod = await import('../../src/lib/session');
-createSession = mod.createSession;
-getSession = mod.getSession;
-destroySession = mod.destroySession;
+beforeAll(async function () {
+  const mod = await import('../../src/lib/session');
+  createSession = mod.createSession;
+  getSession = mod.getSession;
+  destroySession = mod.destroySession;
+});
 
 beforeEach(function () {
   for (const key of Object.keys(cookies)) {

--- a/apps/www/tests/lib/session.test.ts
+++ b/apps/www/tests/lib/session.test.ts
@@ -1,0 +1,105 @@
+import {afterEach, beforeEach, describe, expect, it, mock} from 'bun:test';
+
+const SESSION_SECRET = 'a'.repeat(32);
+const cookies: Record<string, string> = {};
+
+mock.module('@tanstack/react-start', () => ({
+  createServerFn: () => ({handler: (fn: Function) => fn}),
+}));
+
+mock.module('@tanstack/react-start/server', () => ({
+  getCookie: (name: string) => cookies[name] ?? undefined,
+  setCookie: (name: string, value: string) => {
+    cookies[name] = value;
+  },
+}));
+
+mock.module('../../src/lib/env', () => ({
+  env: {
+    ALLOWED_EMAIL: 'admin@example.com',
+    GOOGLE_CLIENT_ID: 'test-client-id',
+    GOOGLE_CLIENT_SECRET: 'test-secret',
+    GOOGLE_CALLBACK_URL: 'http://localhost:3000/auth/callback',
+    SESSION_SECRET,
+    API_KEY: 'test-api-key',
+  },
+}));
+
+type SessionModule = typeof import('../../src/lib/session');
+let createSession: SessionModule['createSession'];
+let getSession: SessionModule['getSession'];
+let destroySession: SessionModule['destroySession'];
+
+const mod = await import('../../src/lib/session');
+createSession = mod.createSession;
+getSession = mod.getSession;
+destroySession = mod.destroySession;
+
+beforeEach(function () {
+  for (const key of Object.keys(cookies)) {
+    delete cookies[key];
+  }
+});
+
+describe('createSession / getSession lifecycle', function () {
+  it('should create a session and retrieve it', async function () {
+    await createSession('admin@example.com');
+
+    const session = await getSession();
+    expect(session).not.toBeNull();
+    expect(session!.email).toBe('admin@example.com');
+    expect(session!.authenticated).toBe(true);
+  });
+
+  it('should return null when no cookie exists', async function () {
+    const session = await getSession();
+    expect(session).toBeNull();
+  });
+});
+
+describe('getSession validation', function () {
+  it('should return null for expired session', async function () {
+    await createSession('admin@example.com');
+
+    // Tamper with the cookie to set expiry in the past
+    const raw = cookies['schwankie_session']!;
+    const payload = JSON.parse(atob(raw));
+    payload.expires = Date.now() - 1000;
+    cookies['schwankie_session'] = btoa(JSON.stringify(payload));
+
+    const session = await getSession();
+    expect(session).toBeNull();
+  });
+
+  it('should return null for invalid signature', async function () {
+    await createSession('admin@example.com');
+
+    const raw = cookies['schwankie_session']!;
+    const payload = JSON.parse(atob(raw));
+    payload.sig = 'invalid-signature-value';
+    cookies['schwankie_session'] = btoa(JSON.stringify(payload));
+
+    const session = await getSession();
+    expect(session).toBeNull();
+  });
+
+  it('should return null for malformed cookie', async function () {
+    cookies['schwankie_session'] = 'not-valid-base64!!!';
+
+    const session = await getSession();
+    expect(session).toBeNull();
+  });
+});
+
+describe('destroySession', function () {
+  it('should clear the session cookie', async function () {
+    await createSession('admin@example.com');
+    expect(cookies['schwankie_session']).toBeTruthy();
+
+    await destroySession();
+    expect(cookies['schwankie_session']).toBe('');
+
+    const session = await getSession();
+    expect(session).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Google OAuth 2.0 login flow for single-user admin authentication
- Cookie-based session management with HMAC signing (Web Crypto API)
- Auth state exposed via TanStack Router root route context (`beforeLoad`)
- Login page, OAuth callback handler, logout server function
- Single allowed email gating via `ALLOWED_EMAIL` env var

## Files
- `apps/www/src/lib/auth.ts` — OAuth helpers (auth URL, token exchange, userinfo fetch)
- `apps/www/src/lib/session.ts` — signed cookie session (create, get, destroy, getAuthState)
- `apps/www/src/lib/env.ts` — env parsing for Google OAuth + session config
- `apps/www/src/routes/auth/login.tsx` — login page with Google sign-in button
- `apps/www/src/routes/auth/callback.tsx` — OAuth callback, token exchange, session creation
- `apps/www/src/routes/__root.tsx` — auth context + AuthControls component

## Verification
- [x] Typecheck passes (`cd apps/www && bunx tsc --noEmit`)
- [x] Route tree regenerated with auth routes

## Test plan
- [ ] Set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_CALLBACK_URL, ALLOWED_EMAIL, SESSION_SECRET env vars
- [ ] Visit /auth/login, click sign in, verify Google consent screen
- [ ] Complete OAuth flow, verify redirect to / with session cookie
- [ ] Verify non-allowed emails are rejected
- [ ] Verify sign out clears session


## Review Summary

**Verdict**: APPROVED | **Score**: 7/10 | **Complexity**: medium | **Risk**: medium

Clean Google OAuth implementation with proper security boundaries — constant-time HMAC signature verification, single allowed-email gating, signed cookie sessions, and solid test coverage of security-sensitive logic paths. Three review rounds; all findings resolved.