### PR TITLE
fix(mobile): stop queue list jump on promote/delete

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,7 +7,8 @@
     "ios": "expo run:ios",
     "android": "expo run:android",
     "web": "expo start --web",
-    "type-check": "tsc --noEmit --project . --skipLibCheck"
+    "type-check": "tsc --noEmit --project . --skipLibCheck",
+    "test": "bun test"
   },
   "dependencies": {
     "@bacons/apple-targets": "^4.0.6",

--- a/apps/mobile/src/app/(tabs)/compendium.tsx
+++ b/apps/mobile/src/app/(tabs)/compendium.tsx
@@ -6,11 +6,12 @@ import {
   TextInput,
   TouchableOpacity,
 } from 'react-native';
-import {useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
+import type {ListRenderItem} from 'react-native';
 import {MaterialIcons} from '@expo/vector-icons';
+import type {LinkData} from 'client';
 import {useColors} from '../../theme/use-colors';
-import {LinkRow} from '../../components/LinkRow';
-import {LinkActions} from '../../components/LinkActions';
+import {CompendiumLinkRow} from '../../components/CompendiumLinkRow';
 import {EmptyState} from '../../components/EmptyState';
 import {FilterStrip} from '../../components/FilterStrip';
 import {TagsDrawer} from '../../components/TagsDrawer';
@@ -49,6 +50,11 @@ export default function CompendiumScreen() {
   const {data: tags = []} = useLinkTags('saved');
 
   const links = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data]);
+
+  const renderItem = useCallback<ListRenderItem<LinkData>>(
+    ({item}) => <CompendiumLinkRow link={item} colors={colors} />,
+    [colors],
+  );
 
   const handleEndReached = () => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -154,20 +160,12 @@ export default function CompendiumScreen() {
       <FlatList
         data={links}
         keyExtractor={(item) => String(item.id)}
-        renderItem={({item}) => (
-          <View>
-            <LinkRow link={item} colors={colors} />
-            <LinkActions url={item.url} colors={colors} />
-          </View>
-        )}
+        renderItem={renderItem}
+        maintainVisibleContentPosition={{minIndexForVisible: 0}}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         refreshControl={
-          <RefreshControl
-            refreshing={isRefetching}
-            onRefresh={refetch}
-            tintColor={colors.accent}
-          />
+          <RefreshControl refreshing={isRefetching} onRefresh={refetch} tintColor={colors.accent} />
         }
         ListEmptyComponent={
           isLoading ? (

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import {View, FlatList, ActivityIndicator, RefreshControl} from 'react-native';
-import {useCallback, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import type {ListRenderItem} from 'react-native';
 import Toast from 'react-native-toast-message';
 import type {LinkData} from 'client';
@@ -27,7 +27,7 @@ export default function QueueScreen() {
   const {mutate: updateLink, isPending: isPromoting} = useUpdateLink();
   const {mutate: deleteLink, isPending: isDeleting} = useDeleteLink();
 
-  const links = data?.pages.flatMap((page) => page.items) ?? [];
+  const links = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data]);
 
   const handleEndReached = () => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1,9 +1,10 @@
 import {View, FlatList, ActivityIndicator, RefreshControl} from 'react-native';
-import {useState} from 'react';
+import {useCallback, useState} from 'react';
+import type {ListRenderItem} from 'react-native';
 import Toast from 'react-native-toast-message';
+import type {LinkData} from 'client';
 import {useColors} from '../../theme/use-colors';
-import {LinkRow} from '../../components/LinkRow';
-import {LinkActions} from '../../components/LinkActions';
+import {QueueLinkRow} from '../../components/QueueLinkRow';
 import {EmptyState} from '../../components/EmptyState';
 import {useDeleteLink, useLinks, useUpdateLink} from '../../services/links';
 
@@ -34,28 +35,56 @@ export default function QueueScreen() {
     }
   };
 
-  const handlePromote = (id: number) => {
-    setPendingPromoteId(id);
-    updateLink(
-      {id, data: {status: 'saved'}},
-      {
-        onSuccess: () => {
-          Toast.show({type: 'success', text1: 'Added to Compendium'});
+  const handlePromote = useCallback(
+    (id: number) => {
+      setPendingPromoteId(id);
+      updateLink(
+        {id, data: {status: 'saved'}},
+        {
+          onSuccess: () => {
+            Toast.show({type: 'success', text1: 'Added to Compendium'});
+          },
+          onSettled: () => setPendingPromoteId(null),
         },
-        onSettled: () => setPendingPromoteId(null),
-      },
-    );
-  };
+      );
+    },
+    [updateLink],
+  );
 
-  const handleDelete = (id: number) => {
-    setPendingDeleteId(id);
-    deleteLink(id, {
-      onSuccess: () => {
-        Toast.show({type: 'success', text1: 'Link deleted'});
-      },
-      onSettled: () => setPendingDeleteId(null),
-    });
-  };
+  const handleDelete = useCallback(
+    (id: number) => {
+      setPendingDeleteId(id);
+      deleteLink(id, {
+        onSuccess: () => {
+          Toast.show({type: 'success', text1: 'Link deleted'});
+        },
+        onSettled: () => setPendingDeleteId(null),
+      });
+    },
+    [deleteLink],
+  );
+
+  const renderItem = useCallback<ListRenderItem<LinkData>>(
+    ({item}) => (
+      <QueueLinkRow
+        link={item}
+        colors={colors}
+        onPromote={handlePromote}
+        onDelete={handleDelete}
+        isPromoting={pendingPromoteId === item.id && isPromoting}
+        isDeleting={pendingDeleteId === item.id && isDeleting}
+      />
+    ),
+    [
+      colors,
+      handlePromote,
+      handleDelete,
+      pendingPromoteId,
+      isPromoting,
+      pendingDeleteId,
+      isDeleting,
+    ],
+  );
 
   if (isLoading) {
     return (
@@ -93,27 +122,12 @@ export default function QueueScreen() {
       <FlatList
         data={links}
         keyExtractor={(item) => String(item.id)}
-        renderItem={({item}) => (
-          <View>
-            <LinkRow link={item} colors={colors} />
-            <LinkActions
-              url={item.url}
-              onPromote={() => handlePromote(item.id)}
-              onDelete={() => handleDelete(item.id)}
-              isPromoting={pendingPromoteId === item.id && isPromoting}
-              isDeleting={pendingDeleteId === item.id && isDeleting}
-              colors={colors}
-            />
-          </View>
-        )}
+        renderItem={renderItem}
+        maintainVisibleContentPosition={{minIndexForVisible: 0}}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         refreshControl={
-          <RefreshControl
-            refreshing={isRefetching}
-            onRefresh={refetch}
-            tintColor={colors.accent}
-          />
+          <RefreshControl refreshing={isRefetching} onRefresh={refetch} tintColor={colors.accent} />
         }
         ListFooterComponent={
           isFetchingNextPage ? (

--- a/apps/mobile/src/components/CompendiumLinkRow.tsx
+++ b/apps/mobile/src/components/CompendiumLinkRow.tsx
@@ -1,0 +1,24 @@
+import {memo} from 'react';
+import {View} from 'react-native';
+import type {LinkData} from 'client';
+import {LinkRow} from './LinkRow';
+import {LinkActions} from './LinkActions';
+import type {lightColors} from '../theme/colors';
+
+type Colors = typeof lightColors;
+
+type CompendiumLinkRowProps = {
+  link: LinkData;
+  colors: Colors;
+};
+
+function CompendiumLinkRowComponent({link, colors}: CompendiumLinkRowProps) {
+  return (
+    <View>
+      <LinkRow link={link} colors={colors} />
+      <LinkActions url={link.url} colors={colors} />
+    </View>
+  );
+}
+
+export const CompendiumLinkRow = memo(CompendiumLinkRowComponent);

--- a/apps/mobile/src/components/QueueLinkRow.tsx
+++ b/apps/mobile/src/components/QueueLinkRow.tsx
@@ -1,0 +1,45 @@
+import {memo, useCallback} from 'react';
+import {View} from 'react-native';
+import type {LinkData} from 'client';
+import {LinkRow} from './LinkRow';
+import {LinkActions} from './LinkActions';
+import type {lightColors} from '../theme/colors';
+
+type Colors = typeof lightColors;
+
+type QueueLinkRowProps = {
+  link: LinkData;
+  colors: Colors;
+  onPromote: (id: number) => void;
+  onDelete: (id: number) => void;
+  isPromoting: boolean;
+  isDeleting: boolean;
+};
+
+function QueueLinkRowComponent({
+  link,
+  colors,
+  onPromote,
+  onDelete,
+  isPromoting,
+  isDeleting,
+}: QueueLinkRowProps) {
+  const handlePromote = useCallback(() => onPromote(link.id), [onPromote, link.id]);
+  const handleDelete = useCallback(() => onDelete(link.id), [onDelete, link.id]);
+
+  return (
+    <View>
+      <LinkRow link={link} colors={colors} />
+      <LinkActions
+        url={link.url}
+        onPromote={handlePromote}
+        onDelete={handleDelete}
+        isPromoting={isPromoting}
+        isDeleting={isDeleting}
+        colors={colors}
+      />
+    </View>
+  );
+}
+
+export const QueueLinkRow = memo(QueueLinkRowComponent);

--- a/apps/mobile/src/services/links-cache.ts
+++ b/apps/mobile/src/services/links-cache.ts
@@ -1,0 +1,25 @@
+import type {InfiniteData} from '@tanstack/react-query';
+import type {LinksResponse} from 'client';
+
+/**
+ * Remove a single link (by id) from an infinite-query cache in place.
+ *
+ * Maps over every page and filters its `items`, leaving `pages` length,
+ * `pageParams`, `hasMore`, and `nextOffset` untouched — pagination is NOT
+ * recomputed. This keeps the visible array referentially stable except for the
+ * one removed row, which is what avoids the VirtualizedList viewport jump.
+ */
+export function removeLinkFromInfiniteData(
+  data: InfiniteData<LinksResponse> | undefined,
+  id: number,
+): InfiniteData<LinksResponse> | undefined {
+  if (!data) return data;
+
+  return {
+    ...data,
+    pages: data.pages.map((page) => ({
+      ...page,
+      items: page.items.filter((item) => item.id !== id),
+    })),
+  };
+}

--- a/apps/mobile/src/services/links.ts
+++ b/apps/mobile/src/services/links.ts
@@ -1,7 +1,20 @@
 import {useInfiniteQuery, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import type {InfiniteData, QueryClient, UseMutationOptions} from '@tanstack/react-query';
 import Toast from 'react-native-toast-message';
 import {createLink, deleteLink, fetchLinks, fetchTags, updateLink} from 'client';
-import type {CreateLinkInput, LinkStatus, UpdateLinkInput} from 'client';
+import type {CreateLinkInput, LinkData, LinksResponse, LinkStatus, UpdateLinkInput} from 'client';
+import {removeLinkFromInfiniteData} from './links-cache';
+
+type LinksSnapshot = Array<[readonly unknown[], InfiniteData<LinksResponse> | undefined]>;
+
+type MutationContext = {previous: LinksSnapshot} | undefined;
+
+function restoreLinksSnapshot(queryClient: QueryClient, previous: LinksSnapshot | undefined): void {
+  if (!previous) return;
+  for (const [key, value] of previous) {
+    queryClient.setQueryData(key, value);
+  }
+}
 
 const PAGE_SIZE = 25;
 
@@ -54,16 +67,41 @@ export function useCreateLink() {
   });
 }
 
-export function useUpdateLink() {
-  const queryClient = useQueryClient();
+type UpdateLinkVariables = {id: number; data: UpdateLinkInput};
 
-  return useMutation({
-    mutationFn: ({id, data}: {id: number; data: UpdateLinkInput}) => updateLink(id, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: ['links']});
+/**
+ * Builds the optimistic-update mutation options. Extracted from the hook so the
+ * `onMutate`/`onError` cache logic is unit-testable against a real QueryClient
+ * without rendering React.
+ */
+export function updateLinkMutationOptions(
+  queryClient: QueryClient,
+): UseMutationOptions<LinkData, Error, UpdateLinkVariables, MutationContext> {
+  return {
+    mutationFn: ({id, data}) => updateLink(id, data),
+    onMutate: async ({id, data}) => {
+      // Only status changes remove the row from the queued list; other updates
+      // fall back to the existing (non-optimistic) behavior.
+      if (!data.status) return undefined;
+
+      await queryClient.cancelQueries({queryKey: ['links', 'queued']});
+      const previous = queryClient.getQueriesData<InfiniteData<LinksResponse>>({
+        queryKey: ['links', 'queued'],
+      });
+      queryClient.setQueriesData<InfiniteData<LinksResponse>>(
+        {queryKey: ['links', 'queued']},
+        (old) => removeLinkFromInfiniteData(old, id),
+      );
+      return {previous};
+    },
+    onSuccess: (_res, {data}) => {
+      // Invalidate the destination list + tag counts only — never the visible
+      // queued query, which is already correct via the optimistic edit.
+      queryClient.invalidateQueries({queryKey: ['links', data.status ?? 'saved']});
       queryClient.invalidateQueries({queryKey: ['tags']});
     },
-    onError: (error) => {
+    onError: (error, _vars, context) => {
+      restoreLinksSnapshot(queryClient, context?.previous);
       console.error('[useUpdateLink] Error:', error);
       Toast.show({
         type: 'error',
@@ -71,19 +109,40 @@ export function useUpdateLink() {
         text2: error instanceof Error ? error.message : 'Unknown error',
       });
     },
-  });
+  };
 }
 
-export function useDeleteLink() {
+export function useUpdateLink() {
   const queryClient = useQueryClient();
+  return useMutation(updateLinkMutationOptions(queryClient));
+}
 
-  return useMutation({
-    mutationFn: (id: number) => deleteLink(id),
+/**
+ * Builds the optimistic-delete mutation options. Extracted from the hook for the
+ * same testability reason as {@link updateLinkMutationOptions}.
+ */
+export function deleteLinkMutationOptions(
+  queryClient: QueryClient,
+): UseMutationOptions<{deleted: boolean}, Error, number, MutationContext> {
+  return {
+    mutationFn: (id) => deleteLink(id),
+    onMutate: async (id) => {
+      // We don't know which list holds the item — snapshot/edit every status.
+      await queryClient.cancelQueries({queryKey: ['links']});
+      const previous = queryClient.getQueriesData<InfiniteData<LinksResponse>>({
+        queryKey: ['links'],
+      });
+      queryClient.setQueriesData<InfiniteData<LinksResponse>>({queryKey: ['links']}, (old) =>
+        removeLinkFromInfiniteData(old, id),
+      );
+      return {previous};
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: ['links']});
+      // The row is already removed optimistically; only refresh tag counts.
       queryClient.invalidateQueries({queryKey: ['tags']});
     },
-    onError: (error) => {
+    onError: (error, _id, context) => {
+      restoreLinksSnapshot(queryClient, context?.previous);
       console.error('[useDeleteLink] Error:', error);
       Toast.show({
         type: 'error',
@@ -91,5 +150,10 @@ export function useDeleteLink() {
         text2: error instanceof Error ? error.message : 'Unknown error',
       });
     },
-  });
+  };
+}
+
+export function useDeleteLink() {
+  const queryClient = useQueryClient();
+  return useMutation(deleteLinkMutationOptions(queryClient));
 }

--- a/apps/mobile/tests/factories.ts
+++ b/apps/mobile/tests/factories.ts
@@ -1,0 +1,40 @@
+import type {InfiniteData} from '@tanstack/react-query';
+import type {LinkData, LinksResponse} from 'client';
+
+export function makeLink(overrides: Partial<LinkData> = {}): LinkData {
+  return {
+    id: 1,
+    url: 'https://example.com',
+    title: 'Example',
+    description: null,
+    imageUrl: null,
+    status: 'queued',
+    content: null,
+    enrichmentFailCount: 0,
+    enrichmentLastError: null,
+    embeddingFailCount: 0,
+    embeddingLastError: null,
+    score: null,
+    createDate: '2026-01-01T00:00:00.000Z',
+    updateDate: '2026-01-01T00:00:00.000Z',
+    tags: [],
+    ...overrides,
+  };
+}
+
+export function makePage(overrides: Partial<LinksResponse> = {}): LinksResponse {
+  return {
+    items: [makeLink()],
+    hasMore: false,
+    nextOffset: 0,
+    total: 1,
+    ...overrides,
+  };
+}
+
+export function makeInfiniteData(pages: LinksResponse[]): InfiniteData<LinksResponse> {
+  return {
+    pages,
+    pageParams: pages.map((_, index) => index * pages.length),
+  };
+}

--- a/apps/mobile/tests/factories.ts
+++ b/apps/mobile/tests/factories.ts
@@ -32,9 +32,12 @@ export function makePage(overrides: Partial<LinksResponse> = {}): LinksResponse 
   };
 }
 
+const PAGE_SIZE = 25;
+
 export function makeInfiniteData(pages: LinksResponse[]): InfiniteData<LinksResponse> {
   return {
     pages,
-    pageParams: pages.map((_, index) => index * pages.length),
+    // Mirror real offset pagination: page 0 → offset 0, page 1 → offset 25, …
+    pageParams: pages.map((_, index) => index * PAGE_SIZE),
   };
 }

--- a/apps/mobile/tests/services/links-cache.test.ts
+++ b/apps/mobile/tests/services/links-cache.test.ts
@@ -1,0 +1,57 @@
+import {describe, it, expect} from 'bun:test';
+import {removeLinkFromInfiniteData} from '../../src/services/links-cache';
+import {makeInfiniteData, makeLink, makePage} from '../factories';
+
+describe('removeLinkFromInfiniteData', () => {
+  it('should remove the matching item from its page', () => {
+    const data = makeInfiniteData([
+      makePage({items: [makeLink({id: 1}), makeLink({id: 2}), makeLink({id: 3})]}),
+    ]);
+
+    const result = removeLinkFromInfiniteData(data, 2);
+
+    const ids = result!.pages[0]!.items.map((item) => item.id);
+    expect(ids).toEqual([1, 3]);
+  });
+
+  it('should be a no-op when the id is absent', () => {
+    const data = makeInfiniteData([makePage({items: [makeLink({id: 1}), makeLink({id: 2})]})]);
+
+    const result = removeLinkFromInfiniteData(data, 99);
+
+    const ids = result!.pages[0]!.items.map((item) => item.id);
+    expect(ids).toEqual([1, 2]);
+  });
+
+  it('should remove from the correct page in multi-page data', () => {
+    const data = makeInfiniteData([
+      makePage({items: [makeLink({id: 1}), makeLink({id: 2})], hasMore: true, nextOffset: 25}),
+      makePage({items: [makeLink({id: 3}), makeLink({id: 4})]}),
+    ]);
+
+    const result = removeLinkFromInfiniteData(data, 3);
+
+    expect(result!.pages[0]!.items.map((i) => i.id)).toEqual([1, 2]);
+    expect(result!.pages[1]!.items.map((i) => i.id)).toEqual([4]);
+  });
+
+  it('should preserve page count, pageParams, hasMore, and nextOffset', () => {
+    const data = makeInfiniteData([
+      makePage({items: [makeLink({id: 1}), makeLink({id: 2})], hasMore: true, nextOffset: 25}),
+      makePage({items: [makeLink({id: 3})], hasMore: false, nextOffset: 50}),
+    ]);
+
+    const result = removeLinkFromInfiniteData(data, 1);
+
+    expect(result!.pages).toHaveLength(2);
+    expect(result!.pageParams).toEqual(data.pageParams);
+    expect(result!.pages[0]!.hasMore).toBe(true);
+    expect(result!.pages[0]!.nextOffset).toBe(25);
+    expect(result!.pages[1]!.hasMore).toBe(false);
+    expect(result!.pages[1]!.nextOffset).toBe(50);
+  });
+
+  it('should return undefined for undefined input', () => {
+    expect(removeLinkFromInfiniteData(undefined, 1)).toBeUndefined();
+  });
+});

--- a/apps/mobile/tests/services/links.test.ts
+++ b/apps/mobile/tests/services/links.test.ts
@@ -1,0 +1,141 @@
+import {describe, it, expect, beforeEach, beforeAll, mock} from 'bun:test';
+import {InfiniteData, QueryClient} from '@tanstack/react-query';
+import type {LinksResponse} from 'client';
+import {makeInfiniteData, makeLink, makePage} from '../factories';
+
+// react-native-toast-message pulls in react-native, which cannot load under
+// bun test — stub it before importing the module under test.
+mock.module('react-native-toast-message', () => ({
+  default: {show: () => {}},
+}));
+
+type Mod = typeof import('../../src/services/links');
+let updateLinkMutationOptions: Mod['updateLinkMutationOptions'];
+let deleteLinkMutationOptions: Mod['deleteLinkMutationOptions'];
+
+beforeAll(async () => {
+  const mod = await import('../../src/services/links');
+  updateLinkMutationOptions = mod.updateLinkMutationOptions;
+  deleteLinkMutationOptions = mod.deleteLinkMutationOptions;
+});
+
+const QUEUED_KEY = ['links', 'queued', {}];
+
+function ids(data: InfiniteData<LinksResponse> | undefined): number[] {
+  return (data?.pages ?? []).flatMap((page) => page.items.map((item) => item.id));
+}
+
+// react-query v5.90 passes a MutationFunctionContext as the trailing arg to
+// every mutation callback.
+function fnContext(queryClient: QueryClient) {
+  return {client: queryClient, meta: undefined};
+}
+
+describe('updateLinkMutationOptions', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  it('should optimistically remove the promoted row from the queued list', async () => {
+    const seeded = makeInfiniteData([
+      makePage({items: [makeLink({id: 1}), makeLink({id: 2}), makeLink({id: 3})]}),
+    ]);
+    queryClient.setQueryData(QUEUED_KEY, seeded);
+
+    const options = updateLinkMutationOptions(queryClient);
+    await options.onMutate!({id: 2, data: {status: 'saved'}}, fnContext(queryClient));
+
+    const after = queryClient.getQueryData<InfiniteData<LinksResponse>>(QUEUED_KEY);
+    expect(ids(after)).toEqual([1, 3]);
+  });
+
+  it('should restore the snapshot on error (rollback)', async () => {
+    const seeded = makeInfiniteData([makePage({items: [makeLink({id: 1}), makeLink({id: 2})]})]);
+    queryClient.setQueryData(QUEUED_KEY, seeded);
+
+    const options = updateLinkMutationOptions(queryClient);
+    const context = await options.onMutate!(
+      {id: 2, data: {status: 'saved'}},
+      fnContext(queryClient),
+    );
+
+    // Sanity: the optimistic edit happened.
+    expect(ids(queryClient.getQueryData(QUEUED_KEY))).toEqual([1]);
+
+    options.onError!(
+      new Error('boom'),
+      {id: 2, data: {status: 'saved'}},
+      context,
+      fnContext(queryClient),
+    );
+
+    expect(ids(queryClient.getQueryData(QUEUED_KEY))).toEqual([1, 2]);
+  });
+
+  it('should skip the optimistic edit for non-status updates', async () => {
+    const seeded = makeInfiniteData([makePage({items: [makeLink({id: 1}), makeLink({id: 2})]})]);
+    queryClient.setQueryData(QUEUED_KEY, seeded);
+
+    const options = updateLinkMutationOptions(queryClient);
+    const context = await options.onMutate!(
+      {id: 1, data: {title: 'Renamed'}},
+      fnContext(queryClient),
+    );
+
+    expect(context).toBeUndefined();
+    expect(ids(queryClient.getQueryData(QUEUED_KEY))).toEqual([1, 2]);
+  });
+});
+
+describe('deleteLinkMutationOptions', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  it('should optimistically remove the deleted row from the queued list', async () => {
+    const seeded = makeInfiniteData([
+      makePage({items: [makeLink({id: 1}), makeLink({id: 2}), makeLink({id: 3})]}),
+    ]);
+    queryClient.setQueryData(QUEUED_KEY, seeded);
+
+    const options = deleteLinkMutationOptions(queryClient);
+    await options.onMutate!(3, fnContext(queryClient));
+
+    expect(ids(queryClient.getQueryData(QUEUED_KEY))).toEqual([1, 2]);
+  });
+
+  it('should restore the snapshot on error (rollback)', async () => {
+    const seeded = makeInfiniteData([makePage({items: [makeLink({id: 1}), makeLink({id: 2})]})]);
+    queryClient.setQueryData(QUEUED_KEY, seeded);
+
+    const options = deleteLinkMutationOptions(queryClient);
+    const context = await options.onMutate!(1, fnContext(queryClient));
+
+    expect(ids(queryClient.getQueryData(QUEUED_KEY))).toEqual([2]);
+
+    options.onError!(new Error('boom'), 1, context, fnContext(queryClient));
+
+    expect(ids(queryClient.getQueryData(QUEUED_KEY))).toEqual([1, 2]);
+  });
+
+  it('should leave other rows and pages intact when removing one item', async () => {
+    const seeded = makeInfiniteData([
+      makePage({items: [makeLink({id: 1}), makeLink({id: 2})], hasMore: true, nextOffset: 25}),
+      makePage({items: [makeLink({id: 3}), makeLink({id: 4})]}),
+    ]);
+    queryClient.setQueryData(QUEUED_KEY, seeded);
+
+    const options = deleteLinkMutationOptions(queryClient);
+    await options.onMutate!(2, fnContext(queryClient));
+
+    const after = queryClient.getQueryData<InfiniteData<LinksResponse>>(QUEUED_KEY);
+    expect(after!.pages).toHaveLength(2);
+    expect(ids(after)).toEqual([1, 3, 4]);
+    expect(after!.pages[0]!.hasMore).toBe(true);
+    expect(after!.pages[0]!.nextOffset).toBe(25);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:www": "bun test --cwd apps/www",
     "test:env": "bun test --cwd packages/env",
     "test:tasks": "bun test --cwd apps/tasks",
+    "test:mobile": "bun test --cwd apps/mobile",
     "db:generate": "bun run --cwd packages/database generate",
     "db:migrate": "bun run --cwd packages/database migrate",
     "deploy:api": "fly deploy --config ./deploy/api/fly.toml --dockerfile ./deploy/api/Dockerfile",


### PR DESCRIPTION
## Problem

In the mobile Queue tab, pressing **Promote** or **Delete** made the `FlatList` visibly jump / scroll-drift, with the drift compounding across successive promotes.

Two root causes:

1. **Blunt invalidate-and-refetch.** `useUpdateLink` / `useDeleteLink` called `invalidateQueries({queryKey: ['links']})`, which refetched every loaded page of the queued `useInfiniteQuery` and replaced `data.pages` wholesale.
2. **Stale VirtualizedList frame cache.** Dynamic-height rows with no `maintainVisibleContentPosition` meant the wholesale array replacement invalidated the index-keyed frame-height cache, recomputing scroll offset and jumping the viewport.

## Fix

**Data layer** (`apps/mobile/src/services/links.ts`)
- `onMutate` removes exactly one item by id from the infinite-query cache (in place), snapshotting for rollback.
- `onError` restores the snapshot.
- `onSuccess` invalidates only the **destination** list (`saved`/compendium) + `['tags']` — never the visible queued query.
- `useCreateLink` is unchanged (not on the jump path).

**List layer** (`index.tsx`, `compendium.tsx`)
- Both `FlatList`s gain `maintainVisibleContentPosition={{minIndexForVisible: 0}}`.
- Rows are extracted into memoized components (`QueueLinkRow`, `CompendiumLinkRow`); handlers and `renderItem` are `useCallback`-stable.
- No `getItemLayout` — heights are genuinely dynamic.

**Testability**
- Extracted the pure cache transform (`removeLinkFromInfiniteData`) and the mutation-options builders so the cache logic and `onMutate`/rollback are unit-testable without a React renderer.
- Wired up `bun test` for `apps/mobile` (+ root `test:mobile`).

## Verification
- `bun run typecheck:mobile` — passes.
- `bun test --cwd apps/mobile` — 11 tests pass (`removeLinkFromInfiniteData` unit tests + `onMutate`/rollback for update & delete).
- Behavioral verification on simulator (no jump, rollback on error, promoted item appears in Compendium) is left for the reviewer — no simulator in this environment.