### PR TITLE
fix(www): clamp related-link titles in edit dialog

### DIFF
--- a/apps/www/src/components/feed/related-rail.tsx
+++ b/apps/www/src/components/feed/related-rail.tsx
@@ -54,7 +54,7 @@ export function RelatedRail({linkId}: RelatedRailProps) {
             href={item.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="truncate font-serif text-[0.85rem] text-text transition-colors hover:text-accent"
+            className="min-w-0 truncate font-serif text-[0.85rem] text-text transition-colors hover:text-accent"
             title={item.title}
           >
             {item.title}


### PR DESCRIPTION
## Summary

Long related-link titles in the Edit Link dialog's "Related" section (`RelatedRail`) overflowed the dialog horizontally, running off the right edge.

Root cause is the classic flexbox truncation bug: each row is a flex container with a `shrink-0` badge and a `truncate` anchor. A flex item defaults to `min-width: auto`, so the anchor refused to shrink below its content's intrinsic width and the existing `truncate` ellipsis never engaged.

## Change

Added `min-w-0` to the related-link `<a>` in `apps/www/src/components/feed/related-rail.tsx`, allowing the flex child to shrink so `truncate` clamps each title with an ellipsis. The existing `title={item.title}` attribute still shows full text on hover.

Single-file, CSS-only fix — no dialog/layout, data-layer, or styling changes.

## Verification

- `bun run typecheck` exits 0 (www + mobile).
- No new lint errors introduced in `related-rail.tsx` (remaining diagnostics are pre-existing repo-wide formatting/array-key issues, unrelated to this change).